### PR TITLE
Change how log property values are converted in the final output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # serilog-sinks-fluentd
-A Sink that writes logs into Fluentd
+
+A Sink that sends structured log events to Fluentd using MessagePack (https://msgpack.org/) format
+
+## Usage
+
+```C#
+var options = new FluentdSinkOptions(host, port);
+options.Tag = $"app.log.{AppName}";
+var logConfig = new LoggerConfiguration()
+  .WriteTo.Fluentd(options);
+```
+
+## Config in fluentd
+
+```
+## built-in TCP input
+## @see http://docs.fluentd.org/articles/in_forward
+<source>
+  @type forward
+  @id input_forward
+</source>
+```

--- a/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/FluentdSinkClient.cs
+++ b/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/FluentdSinkClient.cs
@@ -82,7 +82,8 @@ namespace Serilog.Sinks.Fluentd
 
             foreach (var log in logEvent.Properties)
             {
-                record.Add(log.Key, log.Value.ToString());
+                var logValue = PropertyValueSimplifier.Simplify(log.Value);
+                record.Add(log.Key, logValue);
             }
 
             if (logEvent.Exception != null)

--- a/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/PropertyValueSimplifier.cs
+++ b/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/PropertyValueSimplifier.cs
@@ -1,0 +1,67 @@
+﻿using Serilog.Debugging;
+using Serilog.Events;
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Serilog.Sinks.Fluentd
+{
+    static class PropertyValueSimplifier
+    {
+        // Code taken from: https://github.com/saleem-mirza/serilog-sinks-azure-analytics
+        public static object Simplify(LogEventPropertyValue data)
+        {
+            if (data is ScalarValue value)
+                return value.Value;
+
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            if (data is DictionaryValue dictValue)
+            {
+                var expObject = new ExpandoObject() as IDictionary<string, object>;
+                foreach (var item in dictValue.Elements)
+                {
+                    if (item.Key.Value is string key)
+                        expObject.Add(key, Simplify(item.Value));
+                }
+
+                return expObject;
+            }
+
+            if (data is SequenceValue seq)
+                return seq.Elements.Select(Simplify).ToArray();
+
+            if (!(data is StructureValue str))
+                return null;
+
+            {
+                try
+                {
+                    if (str.TypeTag == null)
+                        return str.Properties.ToDictionary(p => p.Name, p => Simplify(p.Value));
+
+                    if (!str.TypeTag.StartsWith("DictionaryEntry") && !str.TypeTag.StartsWith("KeyValuePair"))
+                        return str.Properties.ToDictionary(p => p.Name, p => Simplify(p.Value));
+
+                    var key = Simplify(str.Properties[0].Value);
+
+                    if (key == null)
+                        return null;
+
+                    var expObject = new ExpandoObject() as IDictionary<string, object>;
+                    expObject.Add(key.ToString(), Simplify(str.Properties[1].Value));
+
+                    return expObject;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.Message);
+                }
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
By using ToString() on the log property values, the final string values end up with double quotes as part of their values. The pull request uses a method that checks the log property value type and returns the correct value.  This code is taken from https://github.com/saleem-mirza/serilog-sinks-azure-analytics.

I have also added simple usage info in the README file.