### PR TITLE
Add support for structured logging & some minor enhancements

### DIFF
--- a/src/Serilog.Sinks.Fluentd/LoggerConfigurationFluentdExtensions.cs
+++ b/src/Serilog.Sinks.Fluentd/LoggerConfigurationFluentdExtensions.cs
@@ -12,11 +12,12 @@ namespace Serilog
 
         public static LoggerConfiguration Fluentd(
             this LoggerSinkConfiguration loggerSinkConfiguration,
-            FluentdSinkOptions option = null)
+            FluentdSinkOptions option = null,
+            LogEventLevel restrictedToMinimumLevel = LogEventLevel.Information)
         {
             var sink = new FluentdSink(option ?? new FluentdSinkOptions(Host, Port, Tag));
 
-            return loggerSinkConfiguration.Sink(sink, LogEventLevel.Information);
+            return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
 
         public static LoggerConfiguration Fluentd(
@@ -24,7 +25,7 @@ namespace Serilog
            string host,
            int port,
            string tag = Tag,
-           LogEventLevel restrictedToMinimumLevel = LogEventLevel.Debug)
+           LogEventLevel restrictedToMinimumLevel = LogEventLevel.Information)
         {
             var sink = new FluentdSink(new FluentdSinkOptions(host, port, tag));
 
@@ -34,7 +35,7 @@ namespace Serilog
         public static LoggerConfiguration Fluentd(
            this LoggerSinkConfiguration loggerSinkConfiguration,
            string udsSocketFilePath,
-           LogEventLevel restrictedToMinimumLevel = LogEventLevel.Debug)
+           LogEventLevel restrictedToMinimumLevel = LogEventLevel.Information)
         {
             var sink = new FluentdSink(new FluentdSinkOptions(udsSocketFilePath));
 

--- a/src/Serilog.Sinks.Fluentd/Serilog.Sinks.Fluentd.csproj
+++ b/src/Serilog.Sinks.Fluentd/Serilog.Sinks.Fluentd.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <Authors>Borys Iermakov</Authors>
     <AssemblyTitle>Serilog.Sinks.Fluentd</AssemblyTitle>
-    <PackageReleaseNotes>0.3.0</PackageReleaseNotes>
+    <PackageReleaseNotes>0.4.0</PackageReleaseNotes>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Description>
       Serilog adapter for Fluentd
@@ -20,9 +20,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MsgPack.Cli" Version="0.7.0" />
+    <PackageReference Include="MsgPack.Cli" Version="1.0.1" />
     <PackageReference Include="Serilog" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/FluentdSinkOptions.cs
+++ b/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/FluentdSinkOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Serilog.Sinks.Fluentd
 {
@@ -18,6 +19,8 @@ namespace Serilog.Sinks.Fluentd
         public TimeSpan Period { get; set; }
         public string Tag { get; set; }
         public string MessageTemplateKey { get; set; }
+        public string MessageKey { get; set; }
+        public IFormatProvider FormatProvider { get; set; }
         public bool UseUnixDomainSocketEndpoit { get; set; }
         public string UdsSocketFilePath { get; set; }
 
@@ -45,6 +48,8 @@ namespace Serilog.Sinks.Fluentd
             Period = TimeSpan.FromSeconds(2);
             Tag = "Tag";
             MessageTemplateKey = "mt";
+            MessageKey = "m";
+            FormatProvider = CultureInfo.InvariantCulture;
             UseUnixDomainSocketEndpoit = false;
             UdsSocketFilePath = String.Empty;
 

--- a/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/ReflectionHelper.cs
+++ b/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/ReflectionHelper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Serilog.Sinks.Fluentd
+{
+    public static class ReflectionHelper
+    {
+        private static readonly HashSet<Type> NumericTypes = new HashSet<Type>
+        {
+            typeof(byte),
+            typeof(sbyte),
+            typeof(ushort),
+            typeof(uint),
+            typeof(ulong),
+            typeof(short),
+            typeof(int),
+            typeof(long),
+            typeof(decimal),
+            typeof(double),
+            typeof(float)
+        };
+
+        public static bool IsNumericType(this Type type) => NumericTypes.Contains(type);
+    }
+}


### PR DESCRIPTION
I'm facing severe issues with current implementation so I managed to spend some time to fix them:

1. Everythig in quotes. Becuase of that you cannot query dates and number ranges
1. Missing null values handling
1. Missing structured values handling
1. Missing template interpolation
1. Missing culture info when formatting values
1. `Thread.Sleep` replaced with proper `Task.Delay`
1. Minor enhancements

---

This is my test code I used to check everything works:

```cs
static void Main(string[] args)
{
    var log = new LoggerConfiguration().WriteTo.Fluentd(new FluentdSinkOptions("127.0.0.1", 24224, "myindex")).CreateLogger();
    var argumentException = new ArgumentException();
    var propertyValue1 = DateTime.Now;
    var propertyValue0 = new
    {
        InnerValue = new {A = 1, B = 2},
        InnerArr = new[] {1,2,3},
        InnerArrWithStruct = new[] {new {C = 1, D = 2}, new {C = 1, D = 2}},
        Nullable = new int?(10),
        NullNullable = new int?(),
        Id = Guid.NewGuid(),
        Text = "HELLO THERE2",
        Span = TimeSpan.FromMilliseconds(123456789),
        DateLocal = propertyValue1,
        DateUtc = DateTime.UtcNow,
        DateOffsetLocal = DateTimeOffset.Now,
        DateOffsetUtc = DateTimeOffset.UtcNow,
        Number = 42
    };
    log.Error(argumentException, "Test template {@Struct}, Date = {Date}, Value = {Value}",
        propertyValue0,
        propertyValue1,
        45);
    log.Information(argumentException, "Test template {@Struct}, Date = {Date}, Value = {Value}",
        propertyValue0,
        propertyValue1,
        45);
    Thread.Sleep(5000); // because of batcher that doesn't send data immediately
}
```

Fixes #14