### PR TITLE
Fix recursion

### DIFF
--- a/src/Serilog.Sinks.Fluentd/Serilog.Sinks.Fluentd.csproj
+++ b/src/Serilog.Sinks.Fluentd/Serilog.Sinks.Fluentd.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <Authors>Borys Iermakov</Authors>
     <AssemblyTitle>Serilog.Sinks.Fluentd</AssemblyTitle>
-    <PackageReleaseNotes>0.4.0</PackageReleaseNotes>
+    <PackageReleaseNotes>0.4.1</PackageReleaseNotes>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Description>
       Serilog adapter for Fluentd


### PR DESCRIPTION
This PR fixes the problem with high `RetryCount` values. For example if you set it to 2000-4000 you will get an overflow. On my machine for ` RetryCount = 5000` and `RetryDelay = TimeSpan.Zero` I get following

```
2020-01-21T14:27:33.1249537Z [Serilog.Sinks.Fluentd] Retry send 1172
2020-01-21T14:27:33.1258691Z [Serilog.Sinks.Fluentd] Send exception Exception of type 'System.Exception' was thrown.
   at Serilog.Sinks.Fluentd.FluentdSinkClient.SendAsync(LogEvent logEvent, Int32 retryCount) in C:\Users\pzixe\Documents\Repos\serilog-sinks-fluentd\src\Serilog.Sinks.Fluentd\Sinks\Fluentd\FluentdSinkClient.cs:line 111
2020-01-21T14:27:33.1272425Z [Serilog.Sinks.Fluentd] Retry send 1173
2020-01-21T14:27:33.1279368Z [Serilog.Sinks.Fluentd] Send exception Exception of type 'System.Exception' was thrown.
   at Serilog.Sinks.Fluentd.FluentdSinkClient.SendAsync(LogEvent logEvent, Int32 retryCount) in C:\Users\pzixe\Documents\Repos\serilog-sinks-fluentd\src\Serilog.Sinks.Fluentd\Sinks\Fluentd\FluentdSinkClient.cs:line 111
2020-01-21T14:27:33.1286322Z [Serilog.Sinks.Fluentd] Retry send 1174
2020-01-21T14:27:33.1290703Z [Serilog.Sinks.Fluentd] Send exception Exception of type 'System.Exception' was thrown.
   at Serilog.Sinks.Fluentd.FluentdSinkClient.SendAsync(LogEvent logEvent, Int32 retryCount) in C:\Users\pzixe\Documents\Repos\serilog-sinks-fluentd\src\Serilog.Sinks.Fluentd\Sinks\Fluentd\FluentdSinkClient.cs:line 111
2020-01-21T14:27:33.1298182Z [Serilog.Sinks.Fluentd] Retry send 1175
Stack overflow.

C:\Users\pzixe\Documents\Repos\serilog-sinks-fluentd\ConsoleApp1\bin\Debug\
netcoreapp3.1\ConsoleApp1.exe (process 31440) exited with code -1073741571.
```