### PR TITLE
Add options for connection managment.

### DIFF
--- a/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/Endpoints/TcpEndpoint.cs
+++ b/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/Endpoints/TcpEndpoint.cs
@@ -1,10 +1,11 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
 namespace Serilog.Sinks.Fluentd.Sinks.Fluentd.Endpoints
 {
-    class TcpEndpoint : IEndpoint
+    internal class TcpEndpoint : IEndpoint
     {
         private readonly FluentdSinkOptions _options;
         private TcpClient _tcpClient;
@@ -48,6 +49,7 @@ namespace Serilog.Sinks.Fluentd.Sinks.Fluentd.Endpoints
         public void Dispose()
         {
             _tcpClient.Client.Dispose();
+            ((IDisposable)_tcpClient).Dispose();
             _tcpClient = null;
         }
     }

--- a/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/FluentdSinkOptions.cs
+++ b/src/Serilog.Sinks.Fluentd/Sinks/Fluentd/FluentdSinkOptions.cs
@@ -23,6 +23,8 @@ namespace Serilog.Sinks.Fluentd
         public IFormatProvider FormatProvider { get; set; }
         public bool UseUnixDomainSocketEndpoit { get; set; }
         public string UdsSocketFilePath { get; set; }
+        public TimeSpan ReconnetRetryPeriod { get; set; }
+        public TimeSpan ConnectionUsefulPeriod { get; set; }
 
         /// <summary>
         /// In case of network related problems, try that amount of times to send message
@@ -35,7 +37,7 @@ namespace Serilog.Sinks.Fluentd
 
         protected FluentdSinkOptions()
         {
-            Host = String.Empty;
+            Host = string.Empty;
             Port = 0;
             ReceiveBufferSize = 8192;
             SendBufferSize = 8192;
@@ -51,10 +53,12 @@ namespace Serilog.Sinks.Fluentd
             MessageKey = "m";
             FormatProvider = CultureInfo.InvariantCulture;
             UseUnixDomainSocketEndpoit = false;
-            UdsSocketFilePath = String.Empty;
+            UdsSocketFilePath = string.Empty;
 
             RetryCount = 10;
             RetryDelay = TimeSpan.FromSeconds(1);
+            ReconnetRetryPeriod = TimeSpan.FromSeconds(0);
+            ConnectionUsefulPeriod = TimeSpan.FromSeconds(0);
         }
 
         public FluentdSinkOptions(string host, int port, string tag = "") : this()


### PR DESCRIPTION
Unconnected servers ( for example shutdown) remains unnoticed
 by the library. This patch allows discarding connections so the situation
can be corrected

New options:

*ConnectionUsefulPeriod:
 If this value is set,  reconnect after elapsed time.

*ReconnetRetryPeriod
 Connection retry interval to not retry so often